### PR TITLE
Hi Jeroen.

### DIFF
--- a/Sources/Umbraco.Extensions/Extract/VortoPropertyExtractItem.cs
+++ b/Sources/Umbraco.Extensions/Extract/VortoPropertyExtractItem.cs
@@ -54,11 +54,13 @@ namespace Umbraco.Extensions.Extract
             string alias, 
             string language = null)
         {
-            var vortoContent = content.GetVortoValue<IPublishedContent>(alias, language);
+            //var vortoContent = content.GetVortoValue<IPublishedContent>(alias, language);
+            var vortoContents = content.GetVortoValue<List<IPublishedContent>>(alias, language);
 
             if (vortoContent != null)
             {
-                vortoContent.ExtractForExamine(extractedContent, language);
+                //vortoContent.ExtractForExamine(extractedContent, language);
+                vortoContents.ForEach(x => x.ExtractForExamine(extractedContent, language));
             }
             else
             {


### PR DESCRIPTION
Thank you for this awesome Multi-search functionallity. It works perfect for me now, but i found a small glitch. In the VortoPropertyExtractItem.cs, you wrote GetVortoValue<PublishedContent>. I assume this is meant for a Vorto property wrapping a Nested Content property? But, This only worked if you have 1 item in the nested content property. Otherwise, the variable vortoContents gets null, and the vortoString gets the string "System.Collections.Generics.List<IPublishedContent>". I changed it to GetVortoValue<List<IPublishedContent>> and then iterate it, and it works perfect for me, every vorto+NE property gets indexed.

Maybe there are a scenario I have´nt thought of, but this works well for me.
Again, thank you!!
